### PR TITLE
Fixed relationships not being namespaced when needed

### DIFF
--- a/src/Way/Tests/Factory.php
+++ b/src/Way/Tests/Factory.php
@@ -310,7 +310,11 @@ class Factory {
      */
     protected function createRelationship($class)
     {
-        return static::create($class)->id;
+        $parent = get_class($this->class);
+        $namespace = $this->isNamespaced($parent)
+                        ? str_replace(substr(strrchr($parent, '\\'), 1), '', $parent)
+                        : null;
+        return static::create($namespace.$class)->id;
     }
 
     /**


### PR DESCRIPTION
Before creating a relationship it does a check to see if the main class is namespaced, and if so, appends the namespace to relationship, otherwise it leaves it as is.

---

Really sorry as I have no idea how to attach a pull request to an existing issue. The issue is described as here: https://github.com/JeffreyWay/Laravel-Test-Helpers/issues/7

This fixes it from what I can tell (my tests now work as they failed before) and your tests all run green still.

Hope that helps :-)
