### PR TITLE
Add missing optional arguments on model mock

### DIFF
--- a/src/Way/Tests/ModelHelpers.php
+++ b/src/Way/Tests/ModelHelpers.php
@@ -59,6 +59,7 @@ trait ModelHelpers {
 
         $class->shouldReceive($type)
               ->with('/' . str_singular($relationship) . '/i')
+              ->withAnyArgs()
               ->once();
 
         $class->$relationship();


### PR DESCRIPTION
Relationship assertions were failing when the model relationship method had extra arguments. For exemple when specifying a primary key on a "hasOne" relationship, like so:

$this->hasOne('Project', 'project_guid');
