### PR TITLE
Relationships robust

### DIFF
--- a/src/Way/Tests/ModelHelpers.php
+++ b/src/Way/Tests/ModelHelpers.php
@@ -21,14 +21,14 @@ trait ModelHelpers {
         $this->assertFalse($model->validate(), 'Did not expect model to pass validation.');
     }
 
-    public function assertBelongsToMany($parent, $child)
+    public function assertBelongsToMany($relation, $class)
     {
-        $this->assertRelationship($parent, $child, 'belongsToMany');
+        $this->assertRelationship($relation, $class, 'belongsToMany');
     }
 
-    public function assertBelongsTo($parent, $child)
+    public function assertBelongsTo($relation, $class)
     {
-        $this->assertRelationship($parent, $child, 'belongsTo');
+        $this->assertRelationship($relation, $class, 'belongsTo');
     }
 
     public function assertHasMany($relation, $class)

--- a/src/Way/Tests/ModelHelpers.php
+++ b/src/Way/Tests/ModelHelpers.php
@@ -21,24 +21,24 @@ trait ModelHelpers {
         $this->assertFalse($model->validate(), 'Did not expect model to pass validation.');
     }
 
-    public function assertBelongsToMany($relation, $class)
+    public function assertBelongsToMany($relation, $class, $relatedClass = null, $key = null)
     {
-        $this->assertRelationship($relation, $class, 'belongsToMany');
+        $this->assertRelationship($relation, $class, 'belongsToMany', $relatedClass, $key);
     }
 
-    public function assertBelongsTo($relation, $class)
+    public function assertBelongsTo($relation, $class, $relatedClass = null, $key = null)
     {
-        $this->assertRelationship($relation, $class, 'belongsTo');
+        $this->assertRelationship($relation, $class, 'belongsTo', $relatedClass, $key);
     }
 
-    public function assertHasMany($relation, $class)
+    public function assertHasMany($relation, $class, $relatedClass = null, $key = null)
     {
-        $this->assertRelationship($relation, $class, 'hasMany');
+        $this->assertRelationship($relation, $class, 'hasMany', $relatedClass, $key);
     }
 
-    public function assertHasOne($relation, $class)
+    public function assertHasOne($relation, $class, $relatedClass = null, $key = null)
     {
-        $this->assertRelationship($relation, $class, 'hasOne');
+        $this->assertRelationship($relation, $class, 'hasOne', $relatedClass, $key);
     }
 
     public function assertRespondsTo($method, $class, $message = null)
@@ -51,17 +51,26 @@ trait ModelHelpers {
         );
     }
 
-    public function assertRelationship($relationship, $class, $type)
+    public function assertRelationship($relationship, $class, $type, $relatedClass = null, $key = null)
     {
+        $relatedClass = $relatedClass
+            ? str_replace('\\', '\\\\', $relatedClass)
+            : str_singular($relationship);
+
         $this->assertRespondsTo($relationship, $class);
 
         $class = Mockery::mock($class."[$type]");
 
-        $class->shouldReceive($type)
-              ->with('/' . str_singular($relationship) . '/i')
+        if ($key) {
+            $class->shouldReceive($type)
+              ->with('/' . $relatedClass . '/i', $key)
               ->once();
+        } else {
+            $class->shouldReceive($type)
+              ->with('/' . $relatedClass . '/i')
+              ->once();
+        }
 
         $class->$relationship();
     }
-
 }

--- a/src/Way/Tests/ModelHelpers.php
+++ b/src/Way/Tests/ModelHelpers.php
@@ -21,24 +21,24 @@ trait ModelHelpers {
         $this->assertFalse($model->validate(), 'Did not expect model to pass validation.');
     }
 
-    public function assertBelongsToMany($relation, $class, $relatedClass = null, $key = null)
+    public function assertBelongsToMany($methodName, $class, $relatedClass = null, $key = null)
     {
-        $this->assertRelationship($relation, $class, 'belongsToMany', $relatedClass, $key);
+        $this->assertRelationship($methodName, $class, 'belongsToMany', $relatedClass, $key);
     }
 
-    public function assertBelongsTo($relation, $class, $relatedClass = null, $key = null)
+    public function assertBelongsTo($methodName, $class, $relatedClass = null, $key = null)
     {
-        $this->assertRelationship($relation, $class, 'belongsTo', $relatedClass, $key);
+        $this->assertRelationship($methodName, $class, 'belongsTo', $relatedClass, $key);
     }
 
-    public function assertHasMany($relation, $class, $relatedClass = null, $key = null)
+    public function assertHasMany($methodName, $class, $relatedClass = null, $key = null)
     {
-        $this->assertRelationship($relation, $class, 'hasMany', $relatedClass, $key);
+        $this->assertRelationship($methodName, $class, 'hasMany', $relatedClass, $key);
     }
 
-    public function assertHasOne($relation, $class, $relatedClass = null, $key = null)
+    public function assertHasOne($methodName, $class, $relatedClass = null, $key = null)
     {
-        $this->assertRelationship($relation, $class, 'hasOne', $relatedClass, $key);
+        $this->assertRelationship($methodName, $class, 'hasOne', $relatedClass, $key);
     }
 
     public function assertRespondsTo($method, $class, $message = null)
@@ -51,13 +51,13 @@ trait ModelHelpers {
         );
     }
 
-    public function assertRelationship($relationship, $class, $type, $relatedClass = null, $key = null)
+    public function assertRelationship($methodName, $class, $type, $relatedClass = null, $key = null)
     {
         $relatedClass = $relatedClass
             ? str_replace('\\', '\\\\', $relatedClass)
-            : str_singular($relationship);
+            : str_singular($methodName);
 
-        $this->assertRespondsTo($relationship, $class);
+        $this->assertRespondsTo($methodName, $class);
 
         $class = Mockery::mock($class."[$type]");
 
@@ -71,6 +71,6 @@ trait ModelHelpers {
               ->once();
         }
 
-        $class->$relationship();
+        $class->$methodName();
     }
 }


### PR DESCRIPTION
This allows relationships to use classes other than the method name and allows the use of custom keys with the syntax

`$this->assertHasMany($methodName, $class, $relatedClass = null, $key = null)`
