### PR TITLE
Add assertInvalid as syntax sugar

### DIFF
--- a/src/Way/Tests/ModelHelpers.php
+++ b/src/Way/Tests/ModelHelpers.php
@@ -21,6 +21,11 @@ trait ModelHelpers {
         $this->assertFalse($model->validate(), 'Did not expect model to pass validation.');
     }
 
+    public function assertInvalid($model)
+    {
+        $this->assertNotValid($model);
+    }
+
     public function assertBelongsToMany($parent, $child)
     {
         $this->assertRelationship($parent, $child, 'belongsToMany');


### PR DESCRIPTION
Hello,

Nicer syntax is often a good thing. The function `assertNotValid()` sounds and feels a little bit odd. `assertInvalid()` is a lot smoother, don't you think?
