### PR TITLE
Bug fix and extensions on relationships

### DIFF
--- a/src/Way/Tests/DataStore.php
+++ b/src/Way/Tests/DataStore.php
@@ -81,7 +81,7 @@ class DataStore {
      */
     public function getBoolean()
     {
-        return false;
+        return 0;
     }
 
     /**

--- a/src/Way/Tests/ModelHelpers.php
+++ b/src/Way/Tests/ModelHelpers.php
@@ -55,13 +55,52 @@ trait ModelHelpers {
     {
         $this->assertRespondsTo($relationship, $class);
 
+        $args = $this->getArgumentsRelationship($relationship, $class, $type);
+
         $class = Mockery::mock($class."[$type]");
 
-        $class->shouldReceive($type)
-              ->with('/' . str_singular($relationship) . '/i')
-              ->once();
+        switch(count($args))
+        {
+            case 1 :
+                $class->shouldReceive($type)
+                      ->once()
+                      ->with('/' . str_singular($relationship) . '/i');
+                break;
+            case 2 :
+                $class->shouldReceive($type)
+                      ->once()
+                      ->with('/' . str_singular($relationship) . '/i', $args[1]);
+                break;
+            case 3 :
+                $class->shouldReceive($type)
+                      ->once()
+                      ->with('/' . str_singular($relationship) . '/i', $args[1], $args[2]);
+                break;
+            case 4 :
+                $class->shouldReceive($type)
+                      ->once()
+                      ->with('/' . str_singular($relationship) . '/i', $args[1], $args[2], $args[3]);
+                break;
+            default :
+                $class->shouldReceive($type)
+                      ->once();
+                break;
+        }
 
         $class->$relationship();
+    }
+
+    public function getArgumentsRelationship($relationship, $class, $type) {
+        $mocked = Mockery::mock($class."[$type]");
+
+        $mocked->shouldReceive($type)
+              ->once()
+              ->andReturnUsing(function ()
+              {
+                return func_get_args();
+              });
+
+        return $mocked->$relationship();
     }
 
 }

--- a/src/Way/Tests/ModelHelpers.php
+++ b/src/Way/Tests/ModelHelpers.php
@@ -41,6 +41,16 @@ trait ModelHelpers {
         $this->assertRelationship($relation, $class, 'hasOne');
     }
 
+    public function assertMorphMany($relation, $class, $morphable)
+    {
+        $this->assertRelationship($relation, $class, 'morphMany');
+    }
+
+    public function assertMorphTo($relation, $class)
+    {
+        $this->assertRelationship($relation, $class, 'morphTo');
+    }
+
     public function assertRespondsTo($method, $class, $message = null)
     {
         $message = $message ?: "Expected the '$class' class to have method, '$method'.";


### PR DESCRIPTION
I had some problems with the getBoolean() method returning 'false'. I have a tinyint validation rule on my boolean field, all my validate assertions where failing because the Factory was not returning a tinyint.

Next to that i added the support for zero or multiple relationship arguments and made the assertions for morphMany and morphTo.
