### PR TITLE
Fix DataStore::getDecimal docblock

### DIFF
--- a/src/Way/Tests/DataStore.php
+++ b/src/Way/Tests/DataStore.php
@@ -56,7 +56,7 @@ class DataStore {
     /**
      * Get random decimal
      *
-     * @return integer
+     * @return float
      */
     public function getDecimal()
     {


### PR DESCRIPTION
As the title says. This PR fixes the docblock of the getDecimal() method in the DataStore class.
