### PR TITLE
Added support for 'enum' and 'set' field types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "way/laravel-test-helpers",
-    "description": "Easier testing in Laravel.",
+    "name": "duellsy/laravel-test-helpers",
+    "description": "Easier testing in Laravel. (for temp use, supporting enums and set fields)",
     "authors": [
         {
             "name": "Jeffrey Way",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "duellsy/laravel-test-helpers",
-    "description": "Easier testing in Laravel. (for temp use, supporting enums and set fields)",
+    "name": "way/laravel-test-helpers",
+    "description": "Easier testing in Laravel.",
     "authors": [
         {
             "name": "Jeffrey Way",

--- a/src/Way/Tests/Factory.php
+++ b/src/Way/Tests/Factory.php
@@ -228,8 +228,13 @@ class Factory {
             return static::$columns[$this->tableName];
         }
 
+        $schema_manager = $this->db->getDoctrineSchemaManager($tableName);
+        // map enum and set to string, since they are not supported yet by doctrine
+        $schema_manager->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+        $schema_manager->getDatabasePlatform()->registerDoctrineTypeMapping('set', 'string');
+
         // This will only run the first time the factory is created.
-        return static::$columns[$this->tableName] = $this->db->getDoctrineSchemaManager()->listTableDetails($tableName)->getColumns();
+        return static::$columns[$this->tableName] = $schema_manager->listTableColumns($tableName);
     }
 
     /**


### PR DESCRIPTION
Enum and Set field type support is lacking in doctrine, [this is a known issue, however it has a known solution as well](http://wildlyinaccurate.com/doctrine-2-resolving-unknown-database-type-enum-requested), I've simply added in the solution so the Factory can support these types of fields.
