### PR TITLE
Add ModelHelpers to TestFacade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,9 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "phpunit/phpunit": "3.7.*",
+        "mockery/mockery": "dev-master"
     },
     "require-dev": {
         "illuminate/support": "4.0.x",

--- a/src/Way/Tests/Assert.php
+++ b/src/Way/Tests/Assert.php
@@ -7,7 +7,17 @@ class Assert extends TestFacade {
         'eq'       => 'assertEquals',
         'has'      => 'assertContains',
         'type'     => 'assertInternalType',
-        'instance' => 'assertInstanceOf'
+        'instance' => 'assertInstanceOf',
+        'isValid' => 'assertValid',
+        'isNotValid' => 'assertNotValid',
+        'belongsToMany' => 'assertBelongsToMany',
+        'belongsTo' => 'assertBelongsTo',
+        'haveMany' => 'assertHasMany',
+        'haveOne' => 'assertHasOne',
+        'morphMany' => 'assertMorphMany',
+        'morphTo' => 'assertMorphTo',
+        'respondsTo' => 'assertRespondsTo',
+        'haveRelationship' => 'assertRelationship'
     );
 
     protected function getMethod($methodName)

--- a/src/Way/Tests/Factory.php
+++ b/src/Way/Tests/Factory.php
@@ -112,6 +112,8 @@ class Factory {
      */
     public static function make($class, $columns = array())
     {
+        static::$isSaving = false;
+
         $instance = new static;
 
         return $instance->fire($class, $columns);

--- a/src/Way/Tests/ModelHelpers.php
+++ b/src/Way/Tests/ModelHelpers.php
@@ -67,33 +67,38 @@ trait ModelHelpers {
 
         $args = $this->getArgumentsRelationship($relationship, $class, $type);
 
-        $class = Mockery::mock($class."[$type]");
+        $class = Mockery::mock($class."[$type]")->shouldIgnoreMissing()->asUndefined();
 
         switch(count($args))
         {
             case 1 :
                 $class->shouldReceive($type)
                       ->once()
-                      ->with('/' . str_singular($relationship) . '/i');
+                      ->with('/' . str_singular($relationship) . '/i')
+                      ->andReturn(Mockery::self());
                 break;
             case 2 :
                 $class->shouldReceive($type)
                       ->once()
-                      ->with('/' . str_singular($relationship) . '/i', $args[1]);
+                      ->with('/' . str_singular($relationship) . '/i', $args[1])
+                      ->andReturn(Mockery::self());
                 break;
             case 3 :
                 $class->shouldReceive($type)
                       ->once()
-                      ->with('/' . str_singular($relationship) . '/i', $args[1], $args[2]);
+                      ->with('/' . str_singular($relationship) . '/i', $args[1], $args[2])
+                      ->andReturn(Mockery::self());
                 break;
             case 4 :
                 $class->shouldReceive($type)
                       ->once()
-                      ->with('/' . str_singular($relationship) . '/i', $args[1], $args[2], $args[3]);
+                      ->with('/' . str_singular($relationship) . '/i', $args[1], $args[2], $args[3])
+                      ->andReturn(Mockery::self());
                 break;
             default :
                 $class->shouldReceive($type)
-                      ->once();
+                      ->once()
+                      ->andReturn(Mockery::self());
                 break;
         }
 
@@ -101,16 +106,20 @@ trait ModelHelpers {
     }
 
     public function getArgumentsRelationship($relationship, $class, $type) {
-        $mocked = Mockery::mock($class."[$type]");
+        $mocked = Mockery::mock($class."[$type]")->shouldIgnoreMissing()->asUndefined();
 
+        $args = array();
+        
         $mocked->shouldReceive($type)
               ->once()
-              ->andReturnUsing(function ()
+              ->andReturnUsing(function () use (&$args)
               {
-                return func_get_args();
+                $args = func_get_args();
+                return Mockery::self();
               });
-
-        return $mocked->$relationship();
+        $mocked->$relationship();
+        
+        return $args;
     }
 
 }

--- a/src/Way/Tests/Should.php
+++ b/src/Way/Tests/Should.php
@@ -3,7 +3,17 @@
 class Should extends TestFacade {
     protected $aliases = array(
         'have' => 'assertContains',
-        'eq'   => 'assertEquals'
+        'eq'   => 'assertEquals',
+        'beValid' => 'assertValid',
+        'beNotValid' => 'assertNotValid',
+        'belongsToMany' => 'assertBelongsToMany',
+        'belongsTo' => 'assertBelongsTo',
+        'haveMany' => 'assertHasMany',
+        'haveOne' => 'assertHasOne',
+        'morphMany' => 'assertMorphMany',
+        'morphTo' => 'assertMorphTo',
+        'respondsTo' => 'assertRespondsTo',
+        'haveRelationship' => 'assertRelationship'
     );
 
     protected function getMethod($methodName)

--- a/src/Way/Tests/TestFacade.php
+++ b/src/Way/Tests/TestFacade.php
@@ -1,7 +1,8 @@
 <?php namespace Way\Tests;
 
 abstract class TestFacade extends \PHPUnit_Framework_Assert {
-
+    use ModelHelpers;
+    
     /**
      * Singleton
      * @var array


### PR DESCRIPTION
Hello, thanks for this nice utility! :)

I'm using it on Laravel and thought about integrating the ModelHelpers inside TestFacade to make easier to use the whole suite in a consistent way. So I'm proposing it here.

This PR add ModelHelper to TestFacade and adds all ModelHelpers method as aliases in Assert and Should, for better consistency.

Thanks for your work!
cheers
